### PR TITLE
[Bug] Silence errors about missing override

### DIFF
--- a/include/ezvis/ezvis.hpp
+++ b/include/ezvis/ezvis.hpp
@@ -43,12 +43,14 @@ template <typename t_base> struct visitable_base {
 
   template <typename t_visitable>
   static constexpr detail::unique_tag_type
-  unique_tag_helper_ezviz__(const t_visitable * /* Dummy parameter for template deduction */) {
+  unique_tag_helper_ezviz__(const t_visitable * = nullptr /* Dummy parameter for template deduction */) {
     return detail::unique_tag<base_type, t_visitable>();
   }
 
+  virtual ezvis::detail::unique_tag_type unique_tag_ezvis__() const { return unique_tag_helper_ezviz__<t_base>(); }
+
 #define EZVIS_VISITABLE()                                                                                              \
-  virtual ezvis::detail::unique_tag_type unique_tag_ezvis__() const { return unique_tag_helper_ezviz__(this); }
+  virtual ezvis::detail::unique_tag_type unique_tag_ezvis__() const override { return unique_tag_helper_ezviz__(this); }
 };
 
 namespace detail {

--- a/test/ezvis.cc
+++ b/test/ezvis.cc
@@ -16,7 +16,6 @@
 namespace {
 
 struct i_base : ezvis::visitable_base<i_base> {
-  EZVIS_VISITABLE();
   virtual ~i_base() {}
 };
 


### PR DESCRIPTION
- Define unique_tag_ezvis__ in visitable_base
- Mark unique_tag_ezvis__ defined by EZVIS_VISITABLE ```override``` to silence warnings